### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides integration with Turso databases for LLMs. This server implements a two-level authentication system to handle both organization-level and database-level operations, making it easy to manage and query Turso databases directly from LLMs.
 
+<a href="https://glama.ai/mcp/servers/hnkzlqoh92">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/hnkzlqoh92/badge" alt="mcp-turso-cloud MCP server" />
+</a>
+
 ## Features
 
 ### 🏢 Organization-Level Operations


### PR DESCRIPTION
This PR adds a badge for the [mcp-turso-cloud](https://glama.ai/mcp/servers/hnkzlqoh92) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/hnkzlqoh92">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/hnkzlqoh92/badge" alt="mcp-turso-cloud MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.